### PR TITLE
Fix Issue with Adding Volume on Windows

### DIFF
--- a/src/SiteInfoVolumes.jsx
+++ b/src/SiteInfoVolumes.jsx
@@ -290,7 +290,7 @@ Also, all source paths must begin with either /Users or /Volumes.`);
 							dialog.showErrorBox('Error', 'Sorry! You must provide a path in C:\\Users.');
 
 							return false;
-						} else if (volume.source.indexOf('/Users') !== 0) {
+						} else if (os.platform() !== 'win32' && volume.source.indexOf('/Users') !== 0) {
 							dialog.showErrorBox('Error', 'Sorry! You must provide a path in /Users.');
 
 							return false;


### PR DESCRIPTION
Windows 10 Home, 64bit. When attempting to "Add Volume", click on "Browse", select a directory location but upon doing so received error which looked like it was expecting a Mac directory (/Users) rather than Windows (C:\Users). The correction I am submitting appears to have fixed the issue for me.

I am not a professional jsx programmer so I am not sure if the submitted code is correct/ideal. But it works!